### PR TITLE
Use a timeout of zero rather than undefined

### DIFF
--- a/pkl-eval/src/index.ts
+++ b/pkl-eval/src/index.ts
@@ -41,7 +41,7 @@ export async function evaluate(mod: string, opts?: Options): Promise<string> {
 
   const process = execFile(getExePath(), args, {
     env: {},
-    timeout: opts?.timeout ? (opts?.timeout * 1000) + 100 : undefined,
+    timeout: opts?.timeout ? (opts?.timeout * 1000) + 100 : 0,
   }, (err, stdout, stderr) => {
     if (err !== null) {
       reject(new Error(`pkl failed with error ${err} and stderr:\n ${stderr}`));


### PR DESCRIPTION
While `undefined` works in node.js, this is technically a `<number>` property according to the docs and zero is spec'd as the correct way to get an unlimited timeout:

https://nodejs.org/api/child_process.html#child_processexecfilefile-args-options-callback

I filed https://github.com/denoland/deno/issues/22261 to fix the upstream issue for better node compat as well.